### PR TITLE
Update README to clarify api directory status

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ app/
   navigation/            # Tab + stack navigation
   common/                # Shared hooks, theme, utils
   features/              # Feature folders (menu, order, ...)
-api/                     # FastAPI edge (printing proxy)
+api/                     # Planned FastAPI edge (printing proxy, not yet implemented)
 ```
-
 See the Phase 1 MVP brief for full module breakdown.


### PR DESCRIPTION
## Summary
- clarify that `api/` directory is planned but not yet implemented

## Testing
- `yarn lint` *(fails: package not present in lockfile)*