### PR TITLE
Add image prep web app

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,8 @@ app/
 api/                     # Planned FastAPI edge (printing proxy, not yet implemented)
 ```
 See the Phase 1 MVP brief for full module breakdown.
+
+## Image Prep Web App
+
+A simple React + Tailwind project lives in `image-prep-app/`. It helps create 9:16 composites with optional heading and banner text. See its README for instructions.
+

--- a/image-prep-app/README.md
+++ b/image-prep-app/README.md
@@ -1,0 +1,17 @@
+# Image Prep Web App
+
+This folder contains a small React application for composing images in a 9:16 portrait layout. It lets you drag and drop images, select from multi-frame templates, add a heading, and overlay a banner at the bottom. The result can be downloaded as a single PNG file.
+
+## Running
+
+This project expects a typical React + Tailwind setup (for example using [Vite](https://vitejs.dev)).
+
+```
+cd image-prep-app
+npm install
+npm run dev
+```
+
+Open `http://localhost:5173` in your browser.
+
+The **Google Drive** option in the UI is not implemented—it falls back to a local download.

--- a/image-prep-app/index.html
+++ b/image-prep-app/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Image Template App</title>
+  <script type="module" src="/src/index.js"></script>
+</head>
+<body class="min-h-screen flex items-center justify-center"></body>
+</html>

--- a/image-prep-app/src/App.jsx
+++ b/image-prep-app/src/App.jsx
@@ -1,0 +1,112 @@
+import React, { useRef, useState, useEffect } from 'react';
+import { templates, RENDER_WIDTH, RENDER_HEIGHT } from './config';
+import { loadImageFromFile, drawImageInFrame, drawText, drawBanner } from './utils';
+
+export default function App() {
+  const [images, setImages] = useState([]);
+  const [template, setTemplate] = useState(1);
+  const [heading, setHeading] = useState('');
+  const [banner, setBanner] = useState('');
+  const [saveDest, setSaveDest] = useState('local');
+  const canvasRef = useRef(null);
+
+  const handleFiles = async (files) => {
+    const imgs = [];
+    for (const file of files) {
+      if (!file.type.startsWith('image/')) continue;
+      const img = await loadImageFromFile(file);
+      imgs.push(img);
+    }
+    setImages(imgs);
+  };
+
+  useEffect(() => { renderCanvas(); }, [images, template, heading, banner]);
+
+  const renderCanvas = async () => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    canvas.width = RENDER_WIDTH;
+    canvas.height = RENDER_HEIGHT;
+    const ctx = canvas.getContext('2d');
+    ctx.fillStyle = 'white';
+    ctx.fillRect(0, 0, canvas.width, canvas.height);
+    const frames = templates[template] || [];
+    for (let i = 0; i < frames.length; i++) {
+      if (images[i]) await drawImageInFrame(ctx, images[i], frames[i]);
+    }
+    if (heading) drawText(ctx, heading);
+    if (banner) drawBanner(ctx, banner);
+  };
+
+  const handleDownload = () => {
+    if (saveDest === 'drive') {
+      alert('Google Drive upload not implemented.');
+      return;
+    }
+    const canvas = canvasRef.current;
+    const url = canvas.toDataURL('image/png');
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = 'composition.png';
+    a.click();
+  };
+
+  const onInputChange = (e) => handleFiles(e.target.files);
+  const onDrop = (e) => {
+    e.preventDefault();
+    handleFiles(e.dataTransfer.files);
+  };
+  const onDragOver = (e) => e.preventDefault();
+
+  return (
+    <div className="p-4 max-w-xl mx-auto">
+      <h1 className="text-2xl font-bold mb-4">Image Templating App</h1>
+      <div
+        className="border-dashed border-2 p-4 mb-4 text-center"
+        onDrop={onDrop}
+        onDragOver={onDragOver}
+      >
+        <p className="mb-2">Drag & Drop images here</p>
+        <input type="file" multiple accept="image/*" onChange={onInputChange} />
+      </div>
+      <div className="mb-4">
+        <label className="mr-2">Template:</label>
+        <select value={template} onChange={(e) => setTemplate(Number(e.target.value))} className="border p-1">
+          <option value={1}>1 frame</option>
+          <option value={2}>2 frames</option>
+          <option value={3}>3 frames</option>
+          <option value={4}>4 frames</option>
+        </select>
+      </div>
+      <div className="mb-2">
+        <input
+          className="border p-1 w-full"
+          type="text"
+          placeholder="Heading"
+          value={heading}
+          onChange={(e) => setHeading(e.target.value)}
+        />
+      </div>
+      <div className="mb-4">
+        <input
+          className="border p-1 w-full"
+          type="text"
+          placeholder="Banner text"
+          value={banner}
+          onChange={(e) => setBanner(e.target.value)}
+        />
+      </div>
+      <div className="mb-4">
+        <label className="mr-2">Save to:</label>
+        <select value={saveDest} onChange={(e) => setSaveDest(e.target.value)} className="border p-1">
+          <option value="local">Local Download</option>
+          <option value="drive">Google Drive</option>
+        </select>
+      </div>
+      <button className="bg-blue-600 text-white px-4 py-2 rounded" onClick={handleDownload}>Download</button>
+      <div className="mt-4 border" style={{ width: '100%', aspectRatio: '9/16' }}>
+        <canvas ref={canvasRef} className="w-full h-full" />
+      </div>
+    </div>
+  );
+}

--- a/image-prep-app/src/config.js
+++ b/image-prep-app/src/config.js
@@ -1,0 +1,21 @@
+export const RENDER_WIDTH = 1080;
+export const RENDER_HEIGHT = 1920;
+
+export const templates = {
+  1: [{ x: 0, y: 0, width: RENDER_WIDTH, height: RENDER_HEIGHT }],
+  2: [
+    { x: 0, y: 0, width: RENDER_WIDTH, height: RENDER_HEIGHT / 2 },
+    { x: 0, y: RENDER_HEIGHT / 2, width: RENDER_WIDTH, height: RENDER_HEIGHT / 2 },
+  ],
+  3: [
+    { x: 0, y: 0, width: RENDER_WIDTH, height: RENDER_HEIGHT / 3 },
+    { x: 0, y: RENDER_HEIGHT / 3, width: RENDER_WIDTH, height: RENDER_HEIGHT / 3 },
+    { x: 0, y: 2 * RENDER_HEIGHT / 3, width: RENDER_WIDTH, height: RENDER_HEIGHT / 3 },
+  ],
+  4: [
+    { x: 0, y: 0, width: RENDER_WIDTH / 2, height: RENDER_HEIGHT / 2 },
+    { x: RENDER_WIDTH / 2, y: 0, width: RENDER_WIDTH / 2, height: RENDER_HEIGHT / 2 },
+    { x: 0, y: RENDER_HEIGHT / 2, width: RENDER_WIDTH / 2, height: RENDER_HEIGHT / 2 },
+    { x: RENDER_WIDTH / 2, y: RENDER_HEIGHT / 2, width: RENDER_WIDTH / 2, height: RENDER_HEIGHT / 2 },
+  ],
+};

--- a/image-prep-app/src/index.css
+++ b/image-prep-app/src/index.css
@@ -1,0 +1,7 @@
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+body {
+  @apply bg-gray-50;
+}

--- a/image-prep-app/src/index.js
+++ b/image-prep-app/src/index.js
@@ -1,0 +1,7 @@
+import React from 'react';
+import { createRoot } from 'react-dom/client';
+import App from './App';
+import './index.css';
+
+const root = createRoot(document.getElementById('root'));
+root.render(<App />);

--- a/image-prep-app/src/utils.js
+++ b/image-prep-app/src/utils.js
@@ -1,0 +1,50 @@
+export function loadImageFromFile(file) {
+  return new Promise((resolve) => {
+    const reader = new FileReader();
+    reader.onload = (e) => {
+      const img = new Image();
+      img.onload = () => resolve(img);
+      img.src = e.target.result;
+    };
+    reader.readAsDataURL(file);
+  });
+}
+
+export async function drawImageInFrame(ctx, img, frame) {
+  const { x, y, width, height } = frame;
+  let source = img;
+  if (img.width > img.height) {
+    const canvas = document.createElement('canvas');
+    canvas.width = img.height;
+    canvas.height = img.width;
+    const rCtx = canvas.getContext('2d');
+    rCtx.translate(canvas.width / 2, canvas.height / 2);
+    rCtx.rotate(-Math.PI / 2);
+    rCtx.drawImage(img, -img.width / 2, -img.height / 2);
+    source = new Image();
+    source.src = canvas.toDataURL();
+    await new Promise(r => (source.onload = r));
+  }
+  const scale = Math.max(width / source.width, height / source.height);
+  const sw = source.width * scale;
+  const sh = source.height * scale;
+  const sx = x + (width - sw) / 2;
+  const sy = y + (height - sh) / 2;
+  ctx.drawImage(source, sx, sy, sw, sh);
+}
+
+export function drawText(ctx, text) {
+  ctx.font = 'bold 64px sans-serif';
+  ctx.fillStyle = 'black';
+  ctx.textAlign = 'center';
+  ctx.fillText(text, ctx.canvas.width / 2, 100);
+}
+
+export function drawBanner(ctx, text) {
+  ctx.fillStyle = 'rgba(0,0,0,0.7)';
+  ctx.fillRect(0, ctx.canvas.height - 80, ctx.canvas.width, 80);
+  ctx.fillStyle = 'white';
+  ctx.font = '48px sans-serif';
+  ctx.textAlign = 'left';
+  ctx.fillText(text, 20, ctx.canvas.height - 25);
+}

--- a/image-prep-app/tailwind.config.js
+++ b/image-prep-app/tailwind.config.js
@@ -1,0 +1,7 @@
+module.exports = {
+  content: ['./src/**/*.{js,jsx}'],
+  theme: {
+    extend: {},
+  },
+  plugins: [],
+};


### PR DESCRIPTION
## Summary
- add a simple React web app in `image-prep-app` for composing images in a 9:16 layout
- update repo README with a link to the new tool

## Testing
- `yarn lint` *(fails: package isn't in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_686b90b3fc6c8320844daea76ed2a7ca